### PR TITLE
fix: make_retriever (chain.py)

### DIFF
--- a/fdua_competition/chain.py
+++ b/fdua_competition/chain.py
@@ -23,7 +23,8 @@ def get_pages(filename: str) -> Iterable[Document]:
 def make_retriever(pages: list[Document]) -> VectorStoreRetriever:
     embeddings = AzureOpenAIEmbeddings(model="embedding")
     vectorstore = InMemoryVectorStore(embedding=embeddings)
-    return vectorstore.add_documents(pages).as_retriever()
+    vectorstore.add_documents(pages)
+    return vectorstore.as_retriever()
 
 
 def get_prompt_template() -> ChatPromptTemplate:


### PR DESCRIPTION
This pull request includes a small change to the `fdua_competition/chain.py` file. The change modifies the `make_retriever` function to separate the addition of documents to the vector store from the retrieval process.

Codebase simplification:

* [`fdua_competition/chain.py`](diffhunk://#diff-b8c903e0fd5ece32b6975a82b99b09476ef1c62d40d28927eec8ff53f00b9d1aL26-R27): Modified the `make_retriever` function to call `vectorstore.add_documents(pages)` separately before returning `vectorstore.as_retriever()`.